### PR TITLE
Fix google meet link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The [CHARTER.md](CHARTER.md) outlines the scope and governance of our group acti
 
 ## Meeting times
 
-[Google Meet](meet.google.com/jgy-nenx-aok) every other Tuesday at 16:00 GTM from Aug 11 TODO <link to calendar>
+[Google Meet](https://meet.google.com/jgy-nenx-aok) every other Tuesday at 16:00 GTM from Aug 11 TODO <link to calendar>
 
 ## Active projects
 


### PR DESCRIPTION
GitHub prepends the link with link to repo if https is neglected,
turning the url into
  https://github.com/ossf/wg-security-tooling/blob/main/meet.google.com/jgy-nenx-aok